### PR TITLE
Add VSC unable to reconnect using SSH fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you connect to a remote machine using **AFS (Andrew File System)**, you might
     ```bash
    rm -r ~/.vscode-server
    ```
-3. **Create a symbolic link pointing from your AFS home firectory to the new folder.**
+3. **Create a symbolic link pointing from your AFS home directory to the new folder.**
     ```bash
     ln -s /eos/user/j/jkowal/vscode-server ~/.vscode-server
     ```

--- a/README.md
+++ b/README.md
@@ -59,3 +59,28 @@ These graphics can be viewed in VSCode using the *ROOT File Viewer* extension.
     3. Click *Install*.
 2. Open a ROOT file by left-clicking on it in the *Explorer* tab.
 3. Select a graphic to display.
+
+---
+
+# Fix VSCode SSH Connection Errors with AFS
+
+If you connect to a remote machine using **AFS (Andrew File System)**, you might encounter a recurring bug that forces you to delete the `.vscode-server` folder from the remote every time you want to reconnect.
+
+## The Fix
+
+1. **Create a dedicated folder for VSCode server files in your EOS home directory.**
+
+   Suppose your username is `jkowal`, run the following command on the remote machine:
+
+   ```bash
+   mkdir -p /eos/user/j/jkowal/vscode-server
+   ```
+
+2. **Remove the existing `.vscode-server` from your AFS home directory.**
+    ```bash
+   rm -r ~/.vscode-server
+   ```
+3. **Create a symbolic link pointing from your AFS home firectory to the new folder.**
+    ```bash
+    ln -s /eos/user/j/jkowal/vscode-server ~/.vscode-server
+    ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # cmssw_vscode
 Recipies to develop CMSSW using VSCode
 
+>  **Contents:**
+> - [Indexing files](#indexing-files): C++ source navigation and setup using `clangd`  
+> - [ROOT files](#root-files): View ROOT files directly in VSCode  
+> - [Fix VSCode SSH Connection Errors with AFS](#fix-vscode-ssh-connection-errors-with-afs): Avoid having to manually delete `.vscode-server` every time your connection drops
+
+> This AFS-related SSH bug tends to come back **periodically** — especially when your **internet connection is unstable or slow** — so it's **definitely worth applying the fix** described at the end.
+
+
 ## Indexing files
 Indexing files allows VSCode to easily resolve references to imported files. This provides:
 - go to definition


### PR DESCRIPTION
This pull request updates the `README.md` file to improve documentation for setting up and troubleshooting VSCode for CMSSW development. The most significant changes include adding a table of contents, detailing a fix for recurring SSH connection errors related to AFS, and providing step-by-step instructions for implementing the fix.

### Documentation improvements:

* Added a **table of contents** to the `README.md` for easier navigation, including links to sections on indexing files, viewing ROOT files, and fixing SSH connection errors.
* Documented a recurring **AFS-related SSH connection bug** and provided a step-by-step guide to fix it by creating a dedicated folder for VSCode server files in the EOS home directory and linking it to the AFS home directory.